### PR TITLE
Add note mentioning info/warn expected at launch (DTSW-3828)

### DIFF
--- a/src/beginner/dtproject/run-on-robot.md
+++ b/src/beginner/dtproject/run-on-robot.md
@@ -45,6 +45,17 @@ Hello from ROBOT_NAME!
 <== App terminated!
 ```
 
+:::{note}
+Some WARNING and INFO messages from `dts` and from the container's entrypoint are expected. Here are some examples:
+
+From `dts`
+* `WARNING:dts:Forced!`
+* `INFO:dts:Running an image for arm64v8 on aarch64.`
+
+Among entrypoint logs of the container:
+* `INFO: The environment variable VEHICLE_NAME is not set. Using 'myduckiebot'.`
+:::
+
 
 ```{admonition} Congratulations 🎉
 You just built and run your first Duckietown-compliant and Duckiebot-compatible Docker image.


### PR DESCRIPTION
Test local build:
![image](https://github.com/duckietown/book-devmanual-software/assets/10885835/bcacb266-18e0-4a2b-a6de-c7dd1cd76ac7)
